### PR TITLE
Upgrade to Oracle Free from Oracle XE

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -14,19 +14,20 @@ on:
       oracle_version:
         description: 'Oracle service version'
         required: false
-        default: '21-slim'
+        default: 'latest'
         type: choice
         options:
+          - 'latest'
+          - '23-slim'
           - '21-slim'
-          - '18-slim'
-          - '11-slim'
+          - 'xe-21-slim'
 
 jobs:
   manual-test:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: gvenzl/oracle-xe:${{ github.event.inputs.oracle_version }}
+        image: gvenzl/oracle-${{ contains(github.event.inputs.oracle_version, 'xe') && 'xe' || 'free' }}:${{ github.event.inputs.oracle_version }}
         env:
           ORACLE_PASSWORD: testpass
         ports:
@@ -87,13 +88,21 @@ jobs:
               echo "=== Database Connection Testing ==="
               echo "Waiting for Oracle database to be ready..."
               
+              # Determine database name based on Oracle version
+              if echo "${{ github.event.inputs.oracle_version }}" | grep -q "xe"; then
+                DB_NAME="xe"
+              else
+                DB_NAME="freepdb1"
+              fi
+              echo "Using database: $DB_NAME"
+              
               max_attempts=30
               attempt=1
               connection_success=false
               
               while [ $attempt -le $max_attempts ]; do
                 echo "Attempt $attempt: Testing Oracle service connection..."
-                if echo 'SELECT 1 FROM DUAL; EXIT;' | timeout 30s sqlplus -s system/testpass@//host.docker.internal:1521/xe >/dev/null 2>&1; then
+                if echo 'SELECT 1 FROM DUAL; EXIT;' | timeout 30s sqlplus -s system/testpass@//host.docker.internal:1521/$DB_NAME >/dev/null 2>&1; then
                   echo "✓ Successfully connected to Oracle database!"
                   connection_success=true
                   break
@@ -108,13 +117,13 @@ jobs:
                 echo ""
                 echo "=== Database Information ==="
                 echo "Oracle Database Version:"
-                echo "SELECT banner FROM v\$version WHERE banner LIKE 'Oracle%'; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/xe
+                echo "SELECT banner FROM v\$version WHERE banner LIKE 'Oracle%'; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/$DB_NAME
                 echo ""
                 echo "Current Date/Time from Database:"
-                echo "SELECT TO_CHAR(SYSDATE, 'YYYY-MM-DD HH24:MI:SS') AS current_time FROM DUAL; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/xe
+                echo "SELECT TO_CHAR(SYSDATE, 'YYYY-MM-DD HH24:MI:SS') AS current_time FROM DUAL; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/$DB_NAME
                 echo ""
                 echo "Database Connection Test:"
-                echo "SELECT 'Hello from Oracle!' AS message FROM DUAL; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/xe
+                echo "SELECT 'Hello from Oracle!' AS message FROM DUAL; EXIT;" | sqlplus -s system/testpass@//host.docker.internal:1521/$DB_NAME
               else
                 echo "⚠ Could not establish database connection within timeout period"
                 echo "This may be expected depending on Oracle service startup time"
@@ -130,7 +139,13 @@ jobs:
             if [ -f test/test-sqlplus.sh ]; then
               chmod +x test/test-sqlplus.sh
               if [ "${{ github.event.inputs.test_connection }}" = "true" ]; then
-                export ORACLE_TEST_CONNECTION='system/testpass@//host.docker.internal:1521/xe'
+                # Determine database name based on Oracle version
+                if echo "${{ github.event.inputs.oracle_version }}" | grep -q "xe"; then
+                  DB_NAME="xe"
+                else
+                  DB_NAME="freepdb1"
+                fi
+                export ORACLE_TEST_CONNECTION="system/testpass@//host.docker.internal:1521/$DB_NAME"
               fi
               ./test/test-sqlplus.sh
             else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       oracle:
-        image: gvenzl/oracle-xe:21-slim
+        image: gvenzl/oracle-free:latest
         env:
           ORACLE_PASSWORD: testpass
         ports:
@@ -41,7 +41,7 @@ jobs:
             echo "Waiting for Oracle database to be ready..."
             timeout=60
             while [ $timeout -gt 0 ]; do
-              if echo 'SELECT 1 FROM DUAL; EXIT;' | timeout 10s sqlplus -s system/testpass@//host.docker.internal:1521/xe >/dev/null 2>&1; then
+              if echo 'SELECT 1 FROM DUAL; EXIT;' | timeout 10s sqlplus -s system/testpass@//host.docker.internal:1521/freepdb1 >/dev/null 2>&1; then
                 echo "✓ Oracle database is ready"
                 break
               fi
@@ -51,7 +51,7 @@ jobs:
             done
 
             # Set database connection for comprehensive tests
-            export ORACLE_TEST_CONNECTION='system/testpass@//host.docker.internal:1521/xe'
+            export ORACLE_TEST_CONNECTION='system/testpass@//host.docker.internal:1521/freepdb1'
 
             # Make test script executable and run it
             chmod +x test/test-sqlplus.sh


### PR DESCRIPTION
- Update main workflow to use gvenzl/oracle-free:latest instead of oracle-xe:21-slim
- Change database connection from /xe to /freepdb1 for Oracle Free
- Update manual test workflow with Oracle Free support
- Add dynamic database name detection (xe vs freepdb1) in manual workflow
- Provide new Oracle version options: latest, 23-slim, 21-slim, xe-21-slim
- Maintain backward compatibility for Oracle XE testing via manual workflow

This addresses the deprecation warning about using old Oracle XE image
and migrates to the recommended Oracle Database Free edition.