### PR TITLE
Fix: Add execute permission to test script in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           echo "🧪 Testing Oracle Instant Client installation..."
           devcontainer up --workspace-folder .
+          devcontainer exec --workspace-folder . chmod +x ./test/test-sqlplus.sh
           devcontainer exec --workspace-folder . ./test/test-sqlplus.sh
 
   build-and-push:


### PR DESCRIPTION
## 🔧 **Problem**
The GitHub Actions workflow was failing with a permission denied error when trying to execute the test script:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "./test/test-sqlplus.sh": permission denied: unknown
Error: Process completed with exit code 126.
```

## 🎯 **Solution**
Added `chmod +x` command to make the test script executable before running it inside the dev container.

## 📋 **Changes Made**
- Added `devcontainer exec --workspace-folder . chmod +x ./test/test-sqlplus.sh` before running the test
- Ensures proper execution permissions for the test script in the container environment

## ✅ **Testing**
This fix resolves the permission denied error and allows the workflow to run the SQLPlus tests successfully.

## 🚀 **Impact**
- Fixes failing GitHub Actions workflow
- Enables automated testing of Oracle Instant Client installation
- Allows successful tag-based image publishing