### PR TITLE
Fix: Correct YAML syntax error in workflow push parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,12 @@ jobs:
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.version.outputs.version }},latest
-          push: ${{ github.event.inputs.publish || 'always' }}
+          push: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
           runCmd: |
             echo "🔍 Verifying SQLPlus installation..."
             sqlplus -version
             echo "✅ Image build completed for version ${{ steps.version.outputs.version }}"
-            if [ "${{ github.event.inputs.publish }}" != "true" ]; then
+            if [ "${{ github.event.inputs.publish }}" != "true" ] && [ "${{ github.event_name }}" != "push" ]; then
               echo "🧪 Test mode - image not published to registry"
             fi
 


### PR DESCRIPTION
## 🐛 **Problem**
The GitHub Actions workflow was failing with a YAML syntax error:

```
##[error]Unexpected push value ('false)'
```

## 🔍 **Root Cause**
The issue was in the `push` parameter of the `devcontainers/ci@v0.3` action:

```yaml
# ❌ BROKEN - Creates invalid YAML when publish=false
push: ${{ github.event.inputs.publish || 'always' }}
```

When `github.event.inputs.publish` is `false`, this evaluates to `'false)'` which is invalid YAML syntax.

## ✅ **Solution**
Fixed the push parameter with proper boolean evaluation:

```yaml
# ✅ FIXED - Proper boolean logic
push: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
```

## 📋 **Changes Made**
1. **Push Parameter Fix**:
   - Changed from `github.event.inputs.publish || 'always'` 
   - To `github.event.inputs.publish == 'true' || github.event_name == 'push'`
   - Ensures proper boolean evaluation for both manual and tag triggers

2. **Conditional Logic Update**:
   - Updated runCmd conditional to handle both trigger types
   - Test mode message shows when neither publish=true nor tag trigger

## 🚀 **Testing Logic**
- **Manual Trigger + Publish=false**: Build only, no push to registry
- **Manual Trigger + Publish=true**: Build and push to registry  
- **Tag Trigger**: Always build and push to registry

## ✅ **Impact**
- Resolves GitHub Actions workflow syntax error
- Enables proper testing workflow with manual triggers
- Maintains tag-based publishing functionality