### PR TITLE
Fix: Use explicit step for push parameter calculation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,21 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
+      - name: Determine push setting
+        id: push
+        run: |
+          if [ "${{ github.event.inputs.publish }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
+            echo "should_push=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_push=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.version.outputs.version }},latest
-          push: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
+          push: ${{ steps.push.outputs.should_push }}
           runCmd: |
             echo "🔍 Verifying SQLPlus installation..."
             sqlplus -version


### PR DESCRIPTION
## 🐛 **Critical Issue**
The workflow is still failing with the same YAML syntax error even after the previous fix:

```
##[error]Unexpected push value ('false)'
```

## 🔍 **Root Cause Analysis**
The `devcontainers/ci@v0.3` action appears to have issues parsing complex boolean expressions in the `push` parameter. Even though the syntax is valid YAML, the action is still receiving malformed values.

## ✅ **Solution: Explicit Step Calculation**
Instead of using inline boolean expressions, this fix uses a dedicated step to explicitly calculate the push value:

### Before (❌ Still Failing):
```yaml
push: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
```

### After (✅ Explicit):
```yaml
- name: Determine push setting
  id: push
  run: |
    if [ "${{ github.event.inputs.publish }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
      echo "should_push=true" >> $GITHUB_OUTPUT
    else
      echo "should_push=false" >> $GITHUB_OUTPUT
    fi

- name: Build and push
  uses: devcontainers/ci@v0.3
  with:
    push: ${{ steps.push.outputs.should_push }}
```

## 🧪 **Logic Validation**
| Scenario | Condition | Output |
|----------|-----------|---------|
| Manual + Publish=true | `"true" = "true"` | `should_push=true` |
| Manual + Publish=false | `"false" = "true"` → false | `should_push=false` |
| Tag trigger | `"push" = "push"` | `should_push=true` |

## 🎯 **Why This Works**
- Explicit string comparisons in bash shell step
- Clean boolean output (`true`/`false`) to GitHub Actions
- No complex YAML expressions for the action to parse
- Clearer debugging with dedicated step output

## ✅ **Expected Result**
- Manual trigger with publish=false: Build only, no registry push
- Manual trigger with publish=true: Build and push to registry
- Tag triggers: Always build and push to registry