### PR TITLE
Fix: Bypass devcontainers push parameter bug with manual push approach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,28 +92,29 @@ jobs:
             type=raw,value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
-      - name: Determine push setting
-        id: push
-        run: |
-          if [ "${{ github.event.inputs.publish }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
-            echo "should_push=true" >> $GITHUB_OUTPUT
-          else
-            echo "should_push=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push
+      - name: Build with devcontainer
         uses: devcontainers/ci@v0.3
         with:
           imageName: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           imageTag: ${{ steps.version.outputs.version }},latest
-          push: ${{ steps.push.outputs.should_push }}
+          push: never
           runCmd: |
             echo "🔍 Verifying SQLPlus installation..."
             sqlplus -version
             echo "✅ Image build completed for version ${{ steps.version.outputs.version }}"
-            if [ "${{ github.event.inputs.publish }}" != "true" ] && [ "${{ github.event_name }}" != "push" ]; then
-              echo "🧪 Test mode - image not published to registry"
-            fi
+
+      - name: Push to registry
+        if: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
+        run: |
+          echo "🚀 Pushing images to registry..."
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          echo "✅ Images pushed successfully"
+
+      - name: Test mode notification
+        if: ${{ github.event.inputs.publish != 'true' && github.event_name != 'push' }}
+        run: |
+          echo "🧪 Test mode - images built but not pushed to registry"
 
       - name: Create release summary
         run: |


### PR DESCRIPTION
## 🎯 **Final Solution to devcontainers/ci Push Parameter Bug**

After multiple attempts to fix the `'false)'` syntax error, this implements a definitive workaround.

## 🐛 **The Persistent Issue**
```
##[error]Unexpected push value ('false)'
```

This error occurs during "Post job cleanup" in the `devcontainers/ci@v0.3` action, suggesting an internal parsing bug that affects **any** dynamic push parameter value.

## ✅ **The Bulletproof Fix**

### Strategy: Complete Avoidance
Instead of trying to work around the action's push parameter parsing, we bypass it entirely:

```yaml
# ✅ ALWAYS WORKS - No dynamic values
- name: Build with devcontainer
  uses: devcontainers/ci@v0.3
  with:
    push: never  # Static value, no parsing issues

# ✅ MANUAL CONTROL - Standard docker commands
- name: Push to registry
  if: ${{ github.event.inputs.publish == 'true' || github.event_name == 'push' }}
  run: |
    docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
    docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
```

## 🚀 **Benefits of This Approach**

1. **Eliminates the Bug**: No dynamic push parameter = no parsing error
2. **Better Control**: Explicit conditional logic using GitHub Actions `if` statements
3. **Clearer Logic**: Separate steps for build vs push operations
4. **Standard Commands**: Uses reliable `docker push` instead of action's internal logic
5. **Easy Debugging**: Clear step separation for troubleshooting

## 🧪 **Testing Scenarios**

| Trigger Type | Publish Input | Build | Push | Notification |
|--------------|---------------|-------|------|--------------|
| Manual | `false` | ✅ | ❌ | "Test mode" |
| Manual | `true` | ✅ | ✅ | None |
| Tag | N/A | ✅ | ✅ | None |

## 🎉 **Expected Outcome**
- **No more `'false)'` errors**
- **Reliable manual testing** with publish=false
- **Automatic tag-based publishing** when tags are pushed
- **Clear feedback** about what's happening in each scenario